### PR TITLE
Enabling token encrypted with Vault in Yaml inline

### DIFF
--- a/yacloud_compute.py
+++ b/yacloud_compute.py
@@ -102,7 +102,7 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
             self.hosts += MessageToDict(hosts)["instances"]
 
     def _init_client(self):
-        sdk = yandexcloud.SDK(token=self.get_option('yacloud_token'))
+        sdk = yandexcloud.SDK(token=str(self.get_option('yacloud_token')))
 
         self.instance_service = sdk.client(InstanceServiceStub)
         self.folder_service = sdk.client(FolderServiceStub)


### PR DESCRIPTION
Tried Vault-encrypted token like this:
```yaml
yacloud_token: !vault |
          $ANSIBLE_VAULT;1.1;AES256
... etc
```

Got a type clash:
```
<class 'ansible.parsing.yaml.objects.AnsibleVaultEncryptedUnicode'>
<class 'ansible.parsing.yaml.objects.AnsibleUnicode'>
```

And YC SDK error message:
```
[WARNING]:  * Failed to parse yacloud_compute.yaml with yacloud_compute plugin:
<_InactiveRpcError of RPC that terminated with:         status = StatusCode.UNAVAILABLE         details = "Getting metadata from plugin failed with error: 'xxx' has type AnsibleVaultEncryptedUnicode, but expected one of: bytes, unicode"
debug_error_string = "{"created":"@1589060928.131171000","description":"Getting metadata from plugin failed with error: 'xxx' has type AnsibleVaultEncryptedUnicode, but expected one of: bytes, unicode","file":"src/core/lib/security/credentials/plugin/plugin_credentials.cc","file_line":79,"grpc_status":14}" >
```

So I've tried to cast it to string and it worked.