### PR TITLE
Allow to set `yacloud_token` with envs

### DIFF
--- a/yacloud_compute.py
+++ b/yacloud_compute.py
@@ -111,12 +111,18 @@ class InventoryModule(BaseInventoryPlugin, Constructable, Cacheable):
 
     def _init_client(self):
         file = self.get_option('yacloud_token_file')
+        token_var = self._vars.get("yacloud_token")
+        
         if file is not None:
             token = open(file).read().strip()
+        elif token_var is not None:
+            token = token_var
         else:
             token = self.get_option('yacloud_token')
         if not token:
-            raise AnsibleError("token it empty. provide either `yacloud_token_file` or `yacloud_token`")
+            raise AnsibleError(
+                "token it empty. provide either "
+                "`yacloud_token_file` or `yacloud_token`")
         sdk = yandexcloud.SDK(token=token)
 
         self.instance_service = sdk.client(InstanceServiceStub)


### PR DESCRIPTION
Example:

inventory file `yacloud_compute.yml`:
```yaml
plugin: yacloud_compute
yacloud_clouds: foo-cloud
yacloud_folders: bar-folder
```

Do not forget to include `-e yacloud_token=...` when running any inventory-related commands: 

```bash
ansible-inventory -e yacloud_token=... --list
```